### PR TITLE
Add anonymizer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A service sales manager especially for freelancers. Built in German, available i
 - PDF export invoices from projects
 - Keep track of expenses
 - Keep track of gifts/donations (e.g. if you're an OS maintainer)
+- Anonymize data in staging/dev environments
 
 ![sales_demo](https://github.com/devmount/sales/assets/5441654/037e8b6b-e673-430f-91c2-39146cc54d1b)
 
@@ -33,13 +34,20 @@ php artisan db:seed            # create initial admin user
 npm i
 ```
 
+## Commands
+
+To anonymize all personal data, run the following command:
+
+```bash
+php artisan db:anonymize
+```
+
 ## Development
 
 To start a local development server, run:
 
 ```bash
-php artisan serve # start dev webserver backend
-npm run dev       # start dev webserver frontend
+php artisan serve # start dev webserver
 ```
 
 Now you can log in on <http://localhost:8000> with the initial admin user credentials (email: `admin@example.com`, password: `Joh.3,16`).

--- a/app/Console/Commands/AnonymizePersonalData.php
+++ b/app/Console/Commands/AnonymizePersonalData.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models;
+use App\Enums\ExpenseCategory;
+
+class AnonymizePersonalData extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:anonymize';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Replace all personal data entries as well as all titles and descriptions with fake placeholder text';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if ('production' == config('app.env')) {
+            abort(403, 'This command should only be run in local/testing environments!');
+            exit;
+        }
+
+        $clients = Models\Client::all();
+        $projects = Models\Project::all();
+        $estimates = Models\Estimate::all();
+        $invoices = Models\Invoice::all();
+        $positions = Models\Position::all();
+        $expenses = Models\Expense::all();
+        $gifts = Models\Gift::all();
+        $total = array_sum([
+            $clients->count(),
+            $projects->count(),
+            $estimates->count(),
+            $invoices->count(),
+            $positions->count(),
+            $expenses->count(),
+            $gifts->count(),
+        ]);
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+        foreach ($clients as $obj) {
+            $name = fake()->company();
+            $obj->name = $name;
+            $obj->short = str($name)->substr(0, 2)->upper();
+            $obj->address = fake()->streetAddress() . "\n" . fake()->postcode() . ' ' . fake()->city();
+            $obj->email = fake()->companyEmail();
+            $obj->phone = fake()->phoneNumber();
+            $obj->save();
+            $bar->advance();
+        }
+        foreach ($projects as $obj) {
+            $obj->title = str(fake()->words(3, true))->headline();
+            $obj->description = implode("\n", fake()->sentences(2));
+            $obj->save();
+            $bar->advance();
+        }
+        foreach ($estimates as $obj) {
+            $obj->title = str(fake()->words(4, true))->ucfirst();
+            $obj->description = implode("\n", fake()->sentences(2));
+            $obj->save();
+            $bar->advance();
+        }
+        foreach ($invoices as $obj) {
+            $obj->title = str(fake()->words(3, true))->headline();
+            $obj->description = implode("\n", fake()->sentences(2));
+            $obj->save();
+            $bar->advance();
+        }
+        foreach ($positions as $obj) {
+            $obj->description = implode("\n", fake()->sentences(2));
+            $obj->save();
+            $bar->advance();
+        }
+        foreach ($expenses as $obj) {
+            if (!in_array($obj->category, ExpenseCategory::taxCategories())) {
+                $obj->description = fake()->sentence();
+                $obj->save();
+                $bar->advance();
+            }
+        }
+        foreach ($gifts as $obj) {
+            $obj->subject = fake()->sentence();
+            $obj->name = fake()->name();
+            $obj->email = fake()->email();
+            $obj->save();
+            $bar->advance();
+        }
+        $bar->finish();
+        $this->newLine();
+        $this->line("Processing finished. $total records updated.");
+    }
+}


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change adds a command to anonymize all personal data and entity titles/descriptions:

```bash
php artisan db:anonymize
```

It isn't executable on production environments.

## Benefits

No data exposition for external testers.

## Applicable Issues

Closes #27 
