### PR TITLE
Fix mandatory project fields

### DIFF
--- a/app/Filament/Resources/ProjectResource.php
+++ b/app/Filament/Resources/ProjectResource.php
@@ -52,6 +52,7 @@ class ProjectResource extends Resource
                             ->label(__('startAt'))
                             ->weekStartsOnMonday()
                             ->suffixIcon('tabler-calendar-plus')
+                            ->required()
                             ->columnSpan(6),
                         Components\DatePicker::make('due_at')
                             ->label(__('dueAt'))
@@ -73,6 +74,7 @@ class ProjectResource extends Resource
                             ->minValue(0.1)
                             ->suffix('h')
                             ->suffixIcon('tabler-clock-exclamation')
+                            ->required()
                             ->columnSpan(6),
                         Components\TextInput::make('price')
                             ->label(__('price'))
@@ -110,7 +112,7 @@ class ProjectResource extends Resource
                         ->longAbsoluteDiffForHumans(Carbon::parse($record->due_at), 2)
                     )
                     ->description(fn (Project $record): string => Carbon::parse($record->start_at)
-                        ->isoFormat('ll') . ' - ' . Carbon::parse($record->due_at)->isoFormat('ll')
+                        ->isoFormat('ll') . ' - ' . ($record->due_at ? Carbon::parse($record->due_at)->isoFormat('ll') : '∞')
                     ),
                 Columns\TextColumn::make('scope')
                     ->label(__('scope'))

--- a/resources/views/filament/resources/project-resource/pages/download-quote.blade.php
+++ b/resources/views/filament/resources/project-resource/pages/download-quote.blade.php
@@ -169,9 +169,9 @@ const quote = {
     title:       '{{ $this->record->title }}',
     description: '{{ str_replace("\n", "\\n", $this->record->description) }}',
     start:       new Date('{{ $this->record->start_at }}'),
-    due:         new Date('{{ $this->record->due_at }}'),
-    hours:       nDigit(billedPerProject ? {{ $this->record->scope }} : {{ $this->record->estimated_hours }}, 1, lang),
-    price:       billedPerProject ? {{ $this->record->price/$this->record->scope }} : {{ $this->record->price }},
+    due:         {!! $this->record->due_at ? "hdate(new Date({$this->record->due_at}))" : "'∞'"!!},
+    hours:       nDigit(billedPerProject ? {{ $this->record->scope ?? '0' }} : {{ $this->record->estimated_hours }}, 1, lang),
+    price:       billedPerProject ? {{ $this->record->scope ? $this->record->price/$this->record->scope : '0' }} : {{ $this->record->price }},
     net:         euro({{ $this->record->estimated_net }}, lang),
     vatRate:     percent(config.vatRate, lang),
     vat:         euro({{ $this->record->estimated_vat }}, lang),
@@ -275,7 +275,7 @@ document.addEventListener('DOMContentLoaded', () => {
     doc.setTextColor(colors.dark).setFontSize(10)
         .setFont('FiraSansRegular').text(label.servicePeriod, 10, 228)
         .setFont('FiraSansExtraLight').text(
-            markerReplace(label.servicePeriodText, [hdate(quote.start), hdate(quote.due)]), 10, 235, { maxWidth: 160 }
+            markerReplace(label.servicePeriodText, [hdate(quote.start), quote.due]), 10, 235, { maxWidth: 160 }
         )
         // .setFontSize(10).text([label.regards, config.name], 10, 244);
     // footer


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change makes the following project fields mandatory:

- `start_at`
- `scope`

Existing projects without values in those fields are properly handled now.

## Benefits

Quotes are downloadable again.

## Applicable Issues

Implements #40 
