### PR TITLE
Fix mandatory estimation fields

### DIFF
--- a/app/Filament/Resources/EstimateResource.php
+++ b/app/Filament/Resources/EstimateResource.php
@@ -41,7 +41,8 @@ class EstimateResource extends Resource
                     ->step(0.1)
                     ->minValue(0.1)
                     ->suffix('h')
-                    ->suffixIcon('tabler-clock-exclamation'),
+                    ->suffixIcon('tabler-clock-exclamation')
+                    ->required(),
                 Components\TextInput::make('weight')
                     ->label(__('weight'))
                     ->numeric()

--- a/app/Filament/Resources/ProjectResource/RelationManagers/EstimatesRelationManager.php
+++ b/app/Filament/Resources/ProjectResource/RelationManagers/EstimatesRelationManager.php
@@ -28,7 +28,8 @@ class EstimatesRelationManager extends RelationManager
                     ->step(0.1)
                     ->minValue(0.1)
                     ->suffix('h')
-                    ->suffixIcon('tabler-clock-exclamation'),
+                    ->suffixIcon('tabler-clock-exclamation')
+                    ->required(),
                 Components\Textarea::make('description')
                     ->label(__('description'))
                     ->autosize()


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change makes `amount` for estimations mandatory.

## Benefits

Estimates without amount cannot be saved anymore.

## Applicable Issues

Implements #41 
