### PR TITLE
Contacting clients only if email exists

### DIFF
--- a/app/Filament/Resources/ClientResource.php
+++ b/app/Filament/Resources/ClientResource.php
@@ -115,6 +115,7 @@ class ClientResource extends Resource
             ->actions(Actions\ActionGroup::make([
                 Actions\EditAction::make()->icon('tabler-edit'),
                 Actions\Action::make('kontaktieren')
+                    ->disabled(fn (Client $record) => !boolval($record->email))
                     ->icon('tabler-mail')
                     ->form(fn (Client $record) => [
                         Components\TextInput::make('subject')


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change disables the Contacting client option in the actions menu, if no email address was given:
![image](https://github.com/devmount/sales/assets/5441654/13080a62-c8cf-409b-be23-9f8d3a0ed64a)


## Benefits

Better UX.

## Applicable Issues

Implements #37 
