### PR TITLE
Fix monthly income widget

### DIFF
--- a/app/Filament/Widgets/SalesChart.php
+++ b/app/Filament/Widgets/SalesChart.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Widgets;
 
+use App\Enums\ExpenseCategory;
 use App\Models\Expense;
 use App\Models\Invoice;
 use Carbon\Carbon;
@@ -33,11 +34,11 @@ class SalesChart extends ChartWidget
             ->oldest('paid_at')
             ->get();
         $expenses = Expense::whereNotNull('expended_at')
-            ->where('taxable', 1)
+            ->whereIn('category', ExpenseCategory::deliverableCategories())
             ->oldest('expended_at')
             ->get();
         $taxes = Expense::whereNotNull('expended_at')
-            ->where('taxable', 0)
+            ->whereIn('category', ExpenseCategory::taxCategories())
             ->oldest('expended_at')
             ->get();
         $period = match($this->filter) {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change fixes data displayed in the monthly net income widget. Taxes were somehow subtracted with a year offset, this was removed.

## Benefits

More accurate numbers for average monthly income widget again.

## Applicable Issues

None.
