### PR TITLE
Apply back payments to the correct year

### DIFF
--- a/app/Filament/Widgets/MonthlyIncomeChart.php
+++ b/app/Filament/Widgets/MonthlyIncomeChart.php
@@ -14,7 +14,7 @@ class MonthlyIncomeChart extends ChartWidget
 {
     protected int | string | array $columnSpan = 4;
     public ?string $filter = 'net';
-    protected static ?string $pollingInterval = '5';
+    protected static ?string $pollingInterval = null;
 
     public function getHeading(): string
     {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR improves the monthly income widget by applying income tax back payments to the corresponding year.

## Applicable Issues

Closes #86
